### PR TITLE
Integrate decision-trail with Auto Dream via memory bridge

### DIFF
--- a/.claude/commands/marmite.md
+++ b/.claude/commands/marmite.md
@@ -14,6 +14,7 @@ Watch for:
 - When they resist scope creep or refuse to react to noisy signals
 - When they correct your process (not just your output)
 - When they coordinate across multiple Claude sessions — handoffs, context-passing, using tools (issues, PRs, files) as communication layers between sessions
+- When a correction from a previous session stuck (you remembered it without being told again) vs when it didn't (they had to re-correct you). This is memory persistence signal — Auto Dream consolidation working or failing.
 
 **Equally important — track when they DON'T do these things:**
 - When they accept output without challenge that warranted scrutiny
@@ -23,6 +24,7 @@ Watch for:
 - When a session coasts — no redirects, no kills, no pushback
 - When they override you and you were actually right
 - When they go down a rabbit hole without a kill switch
+- When they have to re-teach you something that should have persisted in memory — the correction didn't survive consolidation, or was never captured
 
 Both sides matter. The moments they steer AND the moments they don't are equally valuable data.
 
@@ -50,6 +52,9 @@ Format:
 ## Wrong calls
 [Moments the user's judgment was wrong — overrode you when you were right, went down a rabbit hole, missed something obvious. This section can be empty but should never be padded.]
 - [What happened → what would have been better?]
+
+## Memory
+[Did any correction or preference from a previous session persist without being re-taught? Did anything get forgotten that shouldn't have? This tracks whether Auto Dream consolidation is preserving the right signal. Write "No memory signal." if not applicable — e.g. first session or no prior corrections to test.]
 
 ## Pattern
 [One recurring behaviour observed in this session, cross-referenced against previous digests if they exist. Can be positive or negative. If nothing emerged, write "No new pattern."]

--- a/.claude/commands/trail.md
+++ b/.claude/commands/trail.md
@@ -37,6 +37,7 @@ This is the unique value of decision-trail. Surface evidence of:
 - **Meta-cognition** — are they correcting the AI's process, not just its output? Redirecting approach, not just fixing results?
 - **Strategic killing** — are they killing directions early? Or showing sunk-cost attachment?
 - **Interaction style communication** — are they explicitly shaping how the AI works with them? (setting quality bars, defining what's acceptable, reframing how output should look)
+- **Memory persistence** — are corrections sticking across sessions? Are digests showing the same corrections being re-taught, suggesting memory consolidation isn't capturing the right signal? Improvement here means the feedback loop (digest → synthesis → memory bridge → Auto Dream → next session) is working.
 
 ### Trajectory
 - What's changed since earlier sessions? More trust? Less? Different kinds?
@@ -72,10 +73,31 @@ This is the unique value of decision-trail. Surface evidence of:
   absent. "Nothing notable" if nothing is missing.]
 ```
 
+## Memory bridge
+
+After writing the synthesis, extract the 3-5 most durable collaboration preferences — patterns that have been consistent across multiple sessions and should persist in Claude's working memory. Write these to `decisions/synthesis/memory-bridge.md`, overwriting any previous version.
+
+Format:
+
+```markdown
+# Collaboration preferences (auto-generated from synthesis)
+# Last updated: YYYY-MM-DD from [N] sessions
+
+- [Preference 1 — concrete, actionable, grounded in repeated evidence]
+- [Preference 2]
+- [etc.]
+```
+
+Rules for the memory bridge:
+- Only include patterns with evidence across 3+ sessions. No one-offs.
+- Phrase as instructions Claude can act on, not observations about the user. "Check narrative framing before committing" not "User tends to challenge narrative framing."
+- Max 7 preferences. If you can't cut to 7, you're not being selective enough.
+- This file is the handoff to Auto Dream. It should consolidate these into working memory. If a preference stops appearing in digests, it should naturally age out in the next synthesis.
+
 ## After writing
 
 ```bash
-git add decisions/synthesis/YYYY-MM.md
+git add decisions/synthesis/YYYY-MM.md decisions/synthesis/memory-bridge.md
 git commit -m "synthesis: [month year]"
 git push
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,17 @@ This is a practice tool, not a portfolio. The framing is:
 - Ground every synthesis observation in evidence from digests. Don't infer what isn't there.
 - Watch for multi-session coordination patterns — how the user orchestrates parallel Claude sessions is signal.
 
+## Auto Dream integration
+
+Decision-trail and Auto Dream form a feedback loop:
+
+1. `/marmite` captures session digests including memory persistence signals (corrections that stuck vs. had to be re-taught)
+2. `/trail` synthesizes patterns and writes `memory-bridge.md` — the 3-7 most durable collaboration preferences, phrased as actionable instructions
+3. Auto Dream consolidates `memory-bridge.md` into working memory during its normal consolidation cycle
+4. Next session: Claude starts with those preferences already loaded → marmite tracks whether they held
+
+The memory bridge is the handoff point. It ages naturally — preferences that stop appearing in digests drop out at next synthesis. No manual pruning needed.
+
 ## Key references
 
 - [Anthropic AI Fluency Index](https://www.anthropic.com/research/AI-fluency-index) — 4D framework, artifact paradox, 13 unobservable behaviors


### PR DESCRIPTION
## Summary

- **marmite** now tracks memory persistence signals — corrections that stuck across sessions vs. ones that had to be re-taught
- **trail** writes a `memory-bridge.md` after each synthesis: 3-7 durable collaboration preferences phrased as actionable instructions Auto Dream can consolidate
- **CLAUDE.md** documents the feedback loop: marmite captures → trail synthesizes → memory bridge → Auto Dream consolidates → next session starts with preferences loaded → marmite tracks whether they held

## The loop

```
/marmite (captures session + memory signals)
    ↓
/trail (synthesizes patterns → writes memory-bridge.md)
    ↓
Auto Dream (consolidates preferences into working memory)
    ↓
Next session (Claude starts with preferences → marmite tracks if they held)
```

Preferences age out naturally — if a pattern stops appearing in digests, it drops from the bridge at next synthesis.

## Test plan

- [ ] Run `/marmite` in a session, say "wrap" — verify digest includes `## Memory` section
- [ ] Run `/trail` — verify `memory-bridge.md` is generated alongside synthesis
- [ ] Confirm memory bridge preferences are actionable instructions, not observations

https://claude.ai/code/session_01GUB8LLHTnTtfKqLKLoTPsA