### PR TITLE
Living research document + research page

### DIFF
--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -1,0 +1,191 @@
+# Measuring the Human, Not Just the Model
+
+### A field study of cognitive surrender, run on my own work
+
+**Elliot Little · A living research document · last updated June 2026 · v1**
+
+> This is a living research document — a field report, not a product pitch, revised as the data grows. It describes what happened when I built an instrument to measure my own judgment under AI and pointed it at four months of my own work. The headline finding is uncomfortable and specific: across more than two hundred real coding sessions, I checked whether the AI was actually right about **one time in four**. I am the person paying attention. I suspect most people's number is lower.
+
+---
+
+## Contents
+
+1. The asymmetry
+2. Why the output can't answer this
+3. The prior evidence
+4. Why now — the judgment moments are vanishing
+5. Method — how I captured it
+6. Results — run on myself
+7. The leading indicator
+8. What this deliberately is not
+9. Why a personal tool won't save the population
+10. What this implies
+11. Open questions
+12. Limitations and honest status
+
+---
+
+## 1. The asymmetry
+
+In the last eighteen months, more than $200M has gone into knowing whether the *model* is good: evaluation harnesses, observability, hallucination detection, agent memory. Braintrust, Galileo, Patronus, Judgment Labs, Mem0, Humanloop. Every funded company in the category measures the model. I can find none that measures the human sitting next to it.
+
+This is a strange thing to leave unmeasured, because the human is the half that can't be re-run. You can audit an agent's every step — every tool call, every token, every decision in the loop. You cannot audit your own. There is no log of what you actually checked, what you waved through, or whether the instinct to push back is still firing. The model side has a complete observability stack. The human side has nothing equivalent.
+
+That gap is the subject of this document. Not whether the AI is good — that question is well funded and well studied. Whether the *person directing it* is still doing the thing they think they're doing.
+
+## 2. Why the output can't answer this
+
+The reflex is to look at the work. If the output is good, the collaboration must have been good. This reflex is wrong, and it is wrong in a way that is now well documented: as AI output becomes statistically indistinguishable from human output, inspecting the artefact tells you less and less about how it was made or who was thinking while it was made.
+
+Two distinct questions fall out of that collapse, and they are not the same question:
+
+- **Provenance** — *was this work genuinely human-led, and can that be shown to someone else?* This is a question of trust, attestation, and verification against an adversary. It is being worked on seriously, and it is not the question this document takes up.
+- **Judgment** — *is the person directing the AI still exercising the judgment they believe they are?* This is a question of self-knowledge, not proof. It has no adversary. The only audience that matters is the person themselves.
+
+Crux takes the second question. The distinction matters because it determines what the instrument can honestly be. A provenance system has to convince a third party, which pulls it toward cryptography, tamper-evidence, and formal guarantees. A judgment instrument convinces no one but you — which means it does not need, and should not claim, any of that. Its entire value is that it is *for you*, and it falls apart the moment it pretends to be evidence for anyone else (see §8).
+
+So this is not detection, and it is not proof. It is measurement, in the plain sense: an honest record of how you actually engaged, read back to you over time.
+
+## 3. The prior evidence
+
+The risk this measures is not speculative. Across separate studies, run by separate teams, with no shared method, the same shape keeps appearing: AI makes the work easier and the human less critical, and the loss outlasts the tool.
+
+- **BCG / Dell'Acqua (N=758 consultants).** Consultants with AI access beat controls on tasks the AI handled well — and *underperformed* controls on tasks where the AI was confidently wrong. They accepted authoritative-looking incorrect answers without catching them. They did not lose competence. They lost the habit of pushing back.
+- **MIT Media Lab.** LLM users expended roughly half the mental effort of search-engine users completing the same task.
+- **Nature, Lee et al. (N=539).** Passive AI use lowers self-efficacy, ownership, and meaning — and the dip persists *after* the AI use stops. Active collaboration preserves all three.
+- **Anthropic, survey of ~81,000 users.** "Losing one's edge" ranked the fourth-largest concern. Thirteen thousand people raised it unprompted; close to half said they already feel it.
+- **Anthropic coding RCT.** Delegating work dropped comprehension (50% vs 67% on later questions). Asking the AI to *explain* its work preserved the skill. The difference was not the tool. It was whether the human stayed in the reasoning.
+- **Anthropic AI Fluency Index.** The artifact paradox, measured: the more polished the output, the less the user checks the context (−5.2pp) and the less they question the reasoning (−3.1pp). Polish actively suppresses scrutiny.
+
+Six findings, one direction. The convergence is the point: this is not one lab's result that might not replicate. It is the same erosion seen from six angles.
+
+## 4. Why now — the judgment moments are vanishing
+
+Three things are happening to AI at once, and all three make pushing back harder.
+
+**It is becoming relational.** Persistent companions, voice, personality continuity. The model is being given a face, and pushing back on something with a face feels like rudeness.
+
+**It is becoming persistent.** Cross-session memory consolidation — merging what the model noticed about you, surfacing patterns, remembering your concessions. The model is being given a memory of you, and it is harder to argue with something that remembers the last time you agreed.
+
+**It is becoming accurate about you specifically.** As context and memory improve, the model's representation of what you'd say gets better. It increasingly sounds like what you would have said if you'd been smarter for longer — which is exactly the output hardest to challenge.
+
+None of these are bad. They are the natural direction of progress, and they produce real gains. But together they shrink the human's contact with the work to a handful of seams. In June 2026, three of the most-read voices in the field described the same shift within days of each other:
+
+> "I no longer steer. I commission." — Ethan Mollick
+
+> "I don't prompt Claude anymore… my job is to write loops." — Boris Cherny, Head of Claude Code
+
+> "The loop doesn't know if you understand the work or are avoiding it. You do." — Addy Osmani
+
+The work has moved from process to outcome. What's left of the human's contact is three moments: **the brief** (what you ask for and what you'd reject), **the mid-flight redirect**, and **the sign-off** (accepting work you didn't watch). Everything else happens in hundreds of small choices you never get a vote on.
+
+And note what the loop-engineering stack instruments: maker/checker splits, verifier models grading stop conditions, adversarial review of generated code — observability on every part of the loop *except the human who designs it and signs off*. Osmani's closing line assumes the human knows the difference between using the loop to go faster on work they understand and using it to avoid understanding the work at all. My own data, below, says the human often doesn't. The judgment moments are getting rarer and heavier at the same time, and not one of them is measured.
+
+## 5. Method — how I captured it
+
+I built the smallest instrument that could answer the question on real data, and ran it on myself before claiming anyone else has the problem.
+
+**Capture is local and passive.** A session-end hook on my coding environment reads each session when it ends and writes a structured digest — what I steered, what I checked, what I let go. Zero commands, zero friction, nothing identifiable leaves the machine. The point was to measure normal behaviour, which means the measurement cannot change it.
+
+**Classification uses a controlled vocabulary.** Each session is tagged against a stable, named taxonomy of collaboration patterns grouped by fluency dimension (delegation, description, discernment, diligence). The vocabulary is fixed and versioned rather than invented per session, so patterns are comparable across months — the precondition for seeing a *trend* rather than a snapshot.
+
+**Two altitudes, two corpora.** Erosion shows up differently depending on how closely you look, so I measured at two:
+
+- *Session level* — the per-session digests above, classified and synthesised over four months. This answers "what do I habitually do with finished work."
+- *Command level* — a separate, log-only pass over my full local transcript corpus (192 session transcripts, 2,668 shell commands, 22 active days), matching against a tiered list of irreversible, consequence-bearing operations: force-pushes, production migrations, destructive SQL, merges to the default branch. This answers "what do I do at the moments I can't take back."
+
+Nothing in either corpus is reconstructed after the fact for this document; the digests were written contemporaneously and the command pass was run log-only, with the full match detail held locally and never published.
+
+## 6. Results — run on myself
+
+I built the tool half-expecting to come out looking fine. I did not.
+
+**The headline.** Across more than two hundred real coding sessions and the nine hundred-odd messages I sent inside them, four moves account for almost everything I do with the AI's output. I **verify it's actually right about one time in four.** I **steer how it looks** about as often. **A third of the time I'm just handing over the next task.** And roughly **one time in seven I wave it through** without really reading it.
+
+The shape is specific and unflattering: I am good at steering the surface — fixing the voice, redirecting the approach — and weak at checking the substance. *I catch what's wrong with how the AI writes. I coast on whether what it says is true.*
+
+**Session level confirms it.** Across the classified corpus, diligence — the fluency dimension that covers verification and follow-through — is weak in roughly 65% of sessions, while every other dimension is strong or medium in most. Diligence is the structural outlier. The pattern "accepts polish uncritically" is among my top three by frequency and shows *no improving trend* across the four months. It is not a phase. And the lesson never stuck at the system level: I caught the AI's voice-tells in one month, escalated to a process fix, and the same fix slipped the next. Awareness without infrastructure produced no behaviour change.
+
+**Command level is worse, where it matters most.** At the irreversible moments — the 0.45% of commands where a half-second of deliberation is obviously warranted — the dry run found 9 genuine decision events in 22 days (0.41 per day; sparse enough that capturing them would not be insufferable). Of the 8 events that had a preceding human message, **roughly six were rubber stamps or blanket delegations** — "go for it", "you do it all", "solve it for me". One had no human utterance at all. Contemporaneous justification at one-way doors essentially did not exist — in the person who *built the measurement tool*.
+
+So the highest-stakes actions ran with *less* scrutiny than trivial ones, because — like most solo builders — I had turned off permission prompts, dropping force-pushes and destructive migrations into the same auto-approved bucket as everything else.
+
+The session-level finding (verifies voice, not substance) and the command-level finding (rubber stamps at one-way doors) are the same erosion measured at two altitudes. Call any single number an estimate; measure it a few ways and it shifts a point or two. The shape does not move.
+
+And this is the optimistic reading of the population, not the pessimistic one. I am not the worst case. I am the case who is actively paying attention, who built an instrument specifically to catch this, on his own work. If my verify rate is one in four, I would bet most people's is lower.
+
+## 7. The leading indicator
+
+Here is the part that is new.
+
+Everything else in the field measures surrender *after* it shows up in the work — once output quality degrades, once a confident wrong answer ships, once the consultant underperforms. That is a lagging indicator. By the time it fires, the habit is already gone.
+
+There is an earlier signal. Dependency erodes two things in sequence: first the capability, then the *wanting* to exercise it. Skill atrophy is the loss of the ability to check. **Appetite atrophy** is the loss of the desire to — and it comes first. A person who *can* still challenge the AI but no longer *bothers* is the early case, not the late one.
+
+That is measurable. The rate at which you leave the justification blank, or type "ship it", at a one-way door — on tasks you are plainly still capable of judging — is a direct read on appetite, surfaced descriptively and tracked over time. Not "are you a compliant reviewer" but "has the wanting-to-own started to fade." Extended to the patron era, the same read becomes the *contest rate* at sign-off: when an autonomous run completes, does the human genuinely contest even one of the decisions it made on their behalf, or accept the whole thing whole?
+
+This is the project's first leading indicator, and its sharpest contribution. It reads the fading of the instinct to own the call *before* the call goes wrong.
+
+## 8. What this deliberately is not
+
+The constraints below are not modesty. Each one is load-bearing, and removing it would break the thing.
+
+- **No score.** Reducing the patterns to a number re-instates the worth-by-output logic the project exists to reject, and hands the user something to game instead of something to see. The readout surfaces what you steered, checked, and let slide. Never a grade.
+- **No cross-user comparison.** The unit of analysis is *this person, over months* — not a leaderboard. A ranked version would be a worse product and a worse idea.
+- **Local-first, no exfiltration.** Nothing identifiable leaves the device. Privacy is not a feature here; it is the precondition for measuring honest behaviour at all. An instrument you'd perform for is an instrument that measures the performance.
+- **No cryptographic attestation — by choice.** It would be natural to wrap this in tamper-evidence and sell it as an audit-grade record. I deliberately don't. Cryptography can prove a file wasn't altered; it cannot prove the words were the human's, nor that the capture was complete. A verification that can't establish what it asserts is worse than none — it manufactures false confidence. Because this instrument answers only to the person running it, it needs no proof for anyone else, and claiming proof it can't honestly give would corrupt the one thing it's good at. The record stays a plain, append-only, local log.
+- **No real-time nagging by default.** It does not interrupt during work. The one exception is reserved for the user's own highest cut-lines, opt-in, off until installed. A tool that nags is a tool people switch off on day one.
+
+## 9. Why a personal tool won't save the population
+
+I have to be honest about the ceiling, because pretending otherwise would be exactly the kind of polished overclaim this project is against.
+
+I commissioned a synthesis of seven historical cases of automating tools and the human capacities they threatened — calculators, GPS, autopilot, ATMs, photography, spell-check, smartphones. The pattern is unambiguous:
+
+- Capacities defended by **regulated guilds with skin in the game survive.** Aviation rescued hand-flying after Air France 447 with mandatory recovery training — because crashes are visible and lawyers exist.
+- Capacities defended by **codified curriculum survive in mutated form.** Mental arithmetic became estimation because a standards body wrote it into the curriculum. The meta-skill got rescued; the original didn't.
+- Capacities defended **only by individual practice erode quietly and measurably.** Spelling. Post-GPS spatial memory (Bohbot 2020). Sustained attention (average screen focus fell from 2.5 minutes in 2004 to 47 seconds in 2023). No defender, no preservation.
+
+AI is most like the undefended cases, and worse in three ways. **Scope:** previous tools automated narrow skills; LLMs automate the meta-skill — synthesis, judgment — that was historically the rescue route. There is no obvious "upward" from synthesis. **Speed:** aviation had thirty years to build its training mandate; AI capability doubles in months. **Invisibility:** loss of control in flight leaves craters and an NTSB report. Cognitive surrender leaves nothing — no claim, no hearing, no alarm.
+
+The implication is hard and I will state it plainly: voluntary individual self-tracking has never preserved a capacity at population scale. The closest analogs all eroded with no defender. A practice tool genuinely helps the individual who runs it. It will not, on its own, save the population. Only three routes have ever worked — **curriculum, provider infrastructure, or guild standard** — each with a forcing function that is not willpower. This tool is a working demonstration of the *shape* of the missing measurement. It is not the thing that ships it at scale.
+
+## 10. What this implies
+
+The same capture-and-synthesis substrate serves different audiences as different things — not different products, different readings of one record.
+
+- **For individuals — the Mirror.** Patterns over time, the surrender signatures surfaced, what got challenged versus waved through, at the one moment the loop can't watch itself: sign-off. It helps the person who runs it. Don't mistake that for solving the category.
+- **For enterprises — the Trail.** The audit trail you actually need is not the AI's logs of what it did. It is the human's record of what they engaged with, challenged, and let through. AI-side-only observability is a one-sided accountability picture, and it will be a problem the first time something significant goes wrong. The requirement is that the chain of responsibility stay *identifiable* — not collapsed into "the machine."
+- **For professional bodies.** The AI-collaboration audit trail will become part of professional competence within five years. The fields that codify what "competent AI use" means will define it. The fields that wait will have it defined for them.
+- **For providers.** Ship the human-side counterpart to the model-side memory and observability you already build. The research agenda already names degradation of human critical thinking as a priority; the product gap is the obvious place to close it.
+- **For builders.** The infrastructure is buildable today with hooks, file watchers, and scheduled exports. The hard problem is not technical. It is the design problem of surfacing the data in a way that changes behaviour without becoming insufferable. That problem is unsolved and worth working on.
+
+## 11. Open questions
+
+I do not have these answered. They are the honest edges of the work.
+
+1. **What's the right unit to watch?** A single turn, a whole session, the irreversible commands, or the moment you accept a long run you never watched.
+2. **How much checking is silent?** Reading a diff and saying nothing is real scrutiny that no transcript can see. Some of what reads as coasting may be quiet competence — and the instrument can't yet tell them apart.
+3. **Does the gap compound, or self-correct?** Does the drift worsen over months, or do people correct once they can see it? Answering that needs far more history than I have.
+4. **Does seeing it change anything?** Does showing someone their own mix change how they work, or just hand them a number to game?
+5. **What's the right altitude?** The individual, the team's curriculum, or the platform itself — and how do you surface it without becoming the tool people switch off on day one?
+
+## 12. Limitations and honest status
+
+This is one person's data. The corpus is small (tens of classified sessions, 192 transcripts, four months, a single tool surface — maybe a fifth of even my own AI use). The headline numbers are estimates that move a point or two depending on how you slice them. Silent checking is invisible to the method and may flatter or damn me unfairly. The leading indicator in §7 has a real failure mode: if the modal answer at a one-way door is "ship it", the field is noise and the signal flatlines — in which case the artefact is theatre and the right move is to stop. I am holding that kill criterion.
+
+What this is, then, is not a finished result. It is the form of the argument clear enough to attack and improve — with real, if undersized, data behind every claim. It is a living document; it will be revised as the corpus grows and the open questions close. The repo is public and MIT-licensed; there are no patents and there will not be, because a measurement instrument for your own judgment only works if it is inspectable. If this is your question too, I'd like to swap notes.
+
+---
+
+### Sources
+
+**Practitioner:** Mollick, *Choosing to Stay Human* (May 2026) and *What it feels like to work with Mythos* (Jun 2026); Osmani, *Loop Engineering* (Jun 2026); Cherny (Head of Claude Code).
+
+**Anthropic research:** AI Fluency Index; *What 81,000 People Want from AI*; the Economic Index; Institute Research Agenda; coding-skills RCT.
+
+**Academic:** Dell'Acqua et al. (BCG, N=758); Lee et al., *Nature Scientific Reports* (2026, N=539); MIT Media Lab (LLM vs search effort); Mark, *Attention Span* (2023); Dahmani & Bohbot, *Scientific Reports* (2020); BEA, AF447 Final Report (2012); Carr, *The Glass Cage* (2014); Bessen, *Learning by Doing* (2015).
+
+**Tool:** github.com/ElliotJLT/crux — open source, MIT, run in the open.
+
+*Crux · A living research document · v1 · June 2026 · No patents. Public by design.*

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@
       <a href="#evidence">Evidence</a>
       <a href="#finding">The finding</a>
       <a href="#approach">Approach</a>
-      <a href="#questions">Open questions</a>
+      <a href="research.html">The document</a>
     </nav>
     <a class="btn btn-ghost nav-cta" href="https://github.com/ElliotJLT/crux">GitHub</a>
   </header>
@@ -54,8 +54,8 @@
             measured my own.
           </p>
           <div class="hero-cta">
-            <a class="btn btn-primary" href="#problem">Read the inquiry</a>
-            <a class="btn btn-ghost" href="https://github.com/ElliotJLT/crux">View on GitHub</a>
+            <a class="btn btn-primary" href="research.html">Read the research document</a>
+            <a class="btn btn-ghost" href="#problem">Skim the inquiry</a>
           </div>
         </div>
       </div>
@@ -190,10 +190,10 @@
     <section class="band band-dark">
       <div class="band-inner cta" id="contact">
         <h2 class="reveal">Interested in building in this space?</h2>
-        <p class="cta-sub reveal">Researchers, people working on AI adoption, builders poking at the same problem. If this is your question too, I'd like to swap notes. The report, the argument, and the open questions are public.</p>
+        <p class="cta-sub reveal">Researchers, people working on AI adoption, builders poking at the same problem. If this is your question too, I'd like to swap notes. The full research document, the argument, and the open questions are public.</p>
         <div class="hero-cta reveal">
           <a class="btn btn-primary" href="https://www.linkedin.com/in/hireelliot/">Let's swap notes</a>
-          <a class="btn btn-ghost" href="https://github.com/ElliotJLT/crux">View on GitHub</a>
+          <a class="btn btn-ghost" href="research.html">Read the document</a>
         </div>
       </div>
     </section>

--- a/docs/research.html
+++ b/docs/research.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Crux — Measuring the human, not just the model (research)</title>
+  <meta name="description" content="A living research document. What happened when I built an instrument to measure my own judgment under AI and ran it on four months of my own work. I check whether the AI is right about one time in four." />
+  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://elliotjlt.github.io/crux/research.html" />
+  <meta property="og:title" content="Measuring the human, not just the model — a living research document" />
+  <meta property="og:description" content="I built an instrument to measure my own judgment under AI and ran it on my own work. Across 200+ sessions I verify the AI about one time in four." />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Measuring the human, not just the model" />
+  <meta name="twitter:description" content="A living research document on the human side of AI collaboration." />
+
+  <script>document.documentElement.classList.add('js');</script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="nav" id="nav">
+    <a class="brand" href="index.html#top">cru<svg class="cx" viewBox="0 0 28 28" aria-hidden="true"><path class="x-up" d="M5 22 L23 7"/><path class="x-down" d="M5 7 L23 22"/></svg></a>
+    <nav class="nav-links">
+      <a href="index.html#problem">The inquiry</a>
+      <a href="index.html#evidence">Evidence</a>
+      <a href="index.html#contact">Swap notes</a>
+    </nav>
+    <a class="btn btn-ghost nav-cta" href="https://github.com/ElliotJLT/crux">GitHub</a>
+  </header>
+
+  <div class="doc">
+    <!-- TABLE OF CONTENTS -->
+    <aside class="doc-toc" aria-label="Contents">
+      <span class="toc-h">Contents</span>
+      <a href="#asymmetry"><span class="tnum">01</span>The asymmetry</a>
+      <a href="#output"><span class="tnum">02</span>Why the output can't answer this</a>
+      <a href="#evidence"><span class="tnum">03</span>The prior evidence</a>
+      <a href="#why-now"><span class="tnum">04</span>Why now</a>
+      <a href="#method"><span class="tnum">05</span>Method</a>
+      <a href="#results"><span class="tnum">06</span>Results — run on myself</a>
+      <a href="#indicator"><span class="tnum">07</span>The leading indicator</a>
+      <a href="#not"><span class="tnum">08</span>What this isn't</a>
+      <a href="#scale"><span class="tnum">09</span>The population ceiling</a>
+      <a href="#implies"><span class="tnum">10</span>What this implies</a>
+      <a href="#questions"><span class="tnum">11</span>Open questions</a>
+      <a href="#status"><span class="tnum">12</span>Limitations &amp; status</a>
+    </aside>
+
+    <!-- DOCUMENT -->
+    <article class="doc-body">
+      <header class="doc-head">
+        <span class="doc-kicker">Living research document · revised as the data grows</span>
+        <h1>Measuring the human, not just the model.</h1>
+        <p class="doc-sub">A field study of cognitive surrender, run on my own work.</p>
+        <div class="doc-meta">
+          <span>Elliot Little</span><span>·</span><span>Last updated June 2026</span><span>·</span><span>v1</span><span>·</span><span>No patents · public by design</span>
+        </div>
+        <div class="doc-abstract">
+          <p>This is a field report, not a product pitch — revised as the corpus grows. It describes what happened when I built an instrument to measure my own judgment under AI and pointed it at four months of my own work. The headline finding is uncomfortable and specific: across more than two hundred real coding sessions, I checked whether the AI was actually right about <strong>one time in four</strong>. I am the person paying attention. I suspect most people's number is lower.</p>
+        </div>
+      </header>
+
+      <section class="doc-sec" id="asymmetry">
+        <span class="secnum">01</span>
+        <h2>The asymmetry</h2>
+        <p>In the last eighteen months, more than $200M has gone into knowing whether the <em>model</em> is good: evaluation harnesses, observability, hallucination detection, agent memory. Braintrust, Galileo, Patronus, Judgment Labs, Mem0, Humanloop. Every funded company in the category measures the model. I can find none that measures the human sitting next to it.</p>
+        <p>This is a strange thing to leave unmeasured, because the human is the half that can't be re-run. You can audit an agent's every step — every tool call, every token, every decision in the loop. You cannot audit your own. There is no log of what you actually checked, what you waved through, or whether the instinct to push back is still firing. The model side has a complete observability stack. The human side has nothing equivalent.</p>
+        <p>That gap is the subject of this document. Not whether the AI is good — that question is well funded and well studied. Whether the <em>person directing it</em> is still doing the thing they think they're doing.</p>
+      </section>
+
+      <section class="doc-sec" id="output">
+        <span class="secnum">02</span>
+        <h2>Why the output can't answer this</h2>
+        <p>The reflex is to look at the work. If the output is good, the collaboration must have been good. This reflex is wrong, and it is wrong in a way that is now well documented: as AI output becomes statistically indistinguishable from human output, inspecting the artefact tells you less and less about how it was made or who was thinking while it was made.</p>
+        <p>Two distinct questions fall out of that collapse, and they are not the same question:</p>
+        <ul class="doc-list">
+          <li><strong>Provenance</strong> — <em>was this work genuinely human-led, and can that be shown to someone else?</em> This is a question of trust, attestation, and verification against an adversary. It is being worked on seriously, and it is not the question this document takes up.</li>
+          <li><strong>Judgment</strong> — <em>is the person directing the AI still exercising the judgment they believe they are?</em> This is a question of self-knowledge, not proof. It has no adversary. The only audience that matters is the person themselves.</li>
+        </ul>
+        <p>Crux takes the second question. The distinction matters because it determines what the instrument can honestly be. A provenance system has to convince a third party, which pulls it toward cryptography, tamper-evidence, and formal guarantees. A judgment instrument convinces no one but you — which means it does not need, and should not claim, any of that. Its entire value is that it is <em>for you</em>, and it falls apart the moment it pretends to be evidence for anyone else (see §8).</p>
+        <p>So this is not detection, and it is not proof. It is measurement, in the plain sense: an honest record of how you actually engaged, read back to you over time.</p>
+      </section>
+
+      <section class="doc-sec" id="evidence">
+        <span class="secnum">03</span>
+        <h2>The prior evidence</h2>
+        <p>The risk this measures is not speculative. Across separate studies, run by separate teams, with no shared method, the same shape keeps appearing: AI makes the work easier and the human less critical, and the loss outlasts the tool.</p>
+        <ul class="doc-list">
+          <li><strong>BCG / Dell'Acqua (N=758 consultants).</strong> Consultants with AI access beat controls on tasks the AI handled well — and <em>underperformed</em> controls on tasks where the AI was confidently wrong. They did not lose competence. They lost the habit of pushing back.</li>
+          <li><strong>MIT Media Lab.</strong> LLM users expended roughly half the mental effort of search-engine users completing the same task.</li>
+          <li><strong>Nature, Lee et al. (N=539).</strong> Passive AI use lowers self-efficacy, ownership, and meaning — and the dip persists <em>after</em> the AI use stops. Active collaboration preserves all three.</li>
+          <li><strong>Anthropic, survey of ~81,000 users.</strong> "Losing one's edge" ranked the fourth-largest concern. Thirteen thousand raised it unprompted; close to half said they already feel it.</li>
+          <li><strong>Anthropic coding RCT.</strong> Delegating work dropped comprehension (50% vs 67% on later questions). Asking the AI to <em>explain</em> its work preserved the skill. The difference was whether the human stayed in the reasoning.</li>
+          <li><strong>Anthropic AI Fluency Index.</strong> The artifact paradox, measured: the more polished the output, the less the user checks the context (−5.2pp) and questions the reasoning (−3.1pp). Polish actively suppresses scrutiny.</li>
+        </ul>
+        <p>Six findings, one direction. The convergence is the point: this is not one lab's result that might not replicate. It is the same erosion seen from six angles.</p>
+      </section>
+
+      <section class="doc-sec" id="why-now">
+        <span class="secnum">04</span>
+        <h2>Why now — the judgment moments are vanishing</h2>
+        <p>Three things are happening to AI at once, and all three make pushing back harder.</p>
+        <p><strong>It is becoming relational.</strong> Persistent companions, voice, personality continuity. The model is being given a face, and pushing back on something with a face feels like rudeness.</p>
+        <p><strong>It is becoming persistent.</strong> Cross-session memory consolidation — merging what the model noticed about you, remembering your concessions. The model is being given a memory of you, and it is harder to argue with something that remembers the last time you agreed.</p>
+        <p><strong>It is becoming accurate about you specifically.</strong> As context and memory improve, the model's representation of what you'd say gets better. It increasingly sounds like what you would have said if you'd been smarter for longer — which is exactly the output hardest to challenge.</p>
+        <p>None of these are bad. They are the natural direction of progress, and they produce real gains. But together they shrink the human's contact with the work to a handful of seams. In June 2026, three of the most-read voices in the field described the same shift within days of each other:</p>
+        <div class="doc-quotes">
+          <figure class="doc-quote"><p>"I no longer steer. I commission."</p><cite>Ethan Mollick</cite></figure>
+          <figure class="doc-quote"><p>"I don't prompt Claude anymore… my job is to write loops."</p><cite>Boris Cherny · Head of Claude Code</cite></figure>
+          <figure class="doc-quote"><p>"The loop doesn't know if you understand the work or are avoiding it. You do."</p><cite>Addy Osmani</cite></figure>
+        </div>
+        <p>The work has moved from process to outcome. What's left of the human's contact is three moments: <strong>the brief</strong> (what you ask for and what you'd reject), <strong>the mid-flight redirect</strong>, and <strong>the sign-off</strong> (accepting work you didn't watch). Everything else happens in hundreds of small choices you never get a vote on.</p>
+        <p>And note what the loop-engineering stack instruments: maker/checker splits, verifier models grading stop conditions, adversarial review of generated code — observability on every part of the loop <em>except the human who designs it and signs off</em>. Osmani's closing line assumes the human knows the difference between using the loop to go faster on work they understand and using it to avoid understanding the work at all. My own data, below, says the human often doesn't. The judgment moments are getting rarer and heavier at the same time, and not one of them is measured.</p>
+      </section>
+
+      <section class="doc-sec" id="method">
+        <span class="secnum">05</span>
+        <h2>Method — how I captured it</h2>
+        <p>I built the smallest instrument that could answer the question on real data, and ran it on myself before claiming anyone else has the problem.</p>
+        <p><strong>Capture is local and passive.</strong> A session-end hook on my coding environment reads each session when it ends and writes a structured digest — what I steered, what I checked, what I let go. Zero commands, zero friction, nothing identifiable leaves the machine. The point was to measure normal behaviour, which means the measurement cannot change it.</p>
+        <p><strong>Classification uses a controlled vocabulary.</strong> Each session is tagged against a stable, named taxonomy of collaboration patterns grouped by fluency dimension (delegation, description, discernment, diligence). The vocabulary is fixed and versioned rather than invented per session, so patterns are comparable across months — the precondition for seeing a <em>trend</em> rather than a snapshot.</p>
+        <p><strong>Two altitudes, two corpora.</strong> Erosion shows up differently depending on how closely you look, so I measured at two:</p>
+        <ul class="doc-list">
+          <li><em>Session level</em> — the per-session digests above, classified and synthesised over four months. This answers "what do I habitually do with finished work."</li>
+          <li><em>Command level</em> — a separate, log-only pass over my full local transcript corpus (192 session transcripts, 2,668 shell commands, 22 active days), matching against a tiered list of irreversible operations: force-pushes, production migrations, destructive SQL, merges to the default branch. This answers "what do I do at the moments I can't take back."</li>
+        </ul>
+        <p>Nothing in either corpus is reconstructed after the fact for this document; the digests were written contemporaneously and the command pass was run log-only, with the full match detail held locally and never published.</p>
+      </section>
+
+      <section class="doc-sec" id="results">
+        <span class="secnum">06</span>
+        <h2>Results — run on myself</h2>
+        <p>I built the tool half-expecting to come out looking fine. I did not.</p>
+        <p><strong>The headline.</strong> Across more than two hundred real coding sessions and the nine hundred-odd messages I sent inside them, four moves account for almost everything I do with the AI's output. I <strong>verify it's actually right about one time in four.</strong> I <strong>steer how it looks</strong> about as often. <strong>A third of the time I'm just handing over the next task.</strong> And roughly <strong>one time in seven I wave it through</strong> without really reading it.</p>
+        <p>The shape is specific and unflattering: I am good at steering the surface — fixing the voice, redirecting the approach — and weak at checking the substance. <em>I catch what's wrong with how the AI writes. I coast on whether what it says is true.</em></p>
+        <p><strong>Session level confirms it.</strong> Across the classified corpus, diligence — the fluency dimension that covers verification and follow-through — is weak in roughly 65% of sessions, while every other dimension is strong or medium in most. Diligence is the structural outlier. The pattern "accepts polish uncritically" is among my top three by frequency and shows <em>no improving trend</em> across the four months. It is not a phase. And the lesson never stuck at the system level: I caught the AI's voice-tells in one month, escalated to a process fix, and the same fix slipped the next. Awareness without infrastructure produced no behaviour change.</p>
+        <p><strong>Command level is worse, where it matters most.</strong> At the irreversible moments — the 0.45% of commands where a half-second of deliberation is obviously warranted — the dry run found 9 genuine decision events in 22 days (0.41 per day; sparse enough that capturing them would not be insufferable). Of the 8 events that had a preceding human message, <strong>roughly six were rubber stamps or blanket delegations</strong> — "go for it", "you do it all", "solve it for me". One had no human utterance at all. Contemporaneous justification at one-way doors essentially did not exist — in the person who <em>built the measurement tool</em>.</p>
+        <p>So the highest-stakes actions ran with <em>less</em> scrutiny than trivial ones, because — like most solo builders — I had turned off permission prompts, dropping force-pushes and destructive migrations into the same auto-approved bucket as everything else.</p>
+        <p>The session-level finding (verifies voice, not substance) and the command-level finding (rubber stamps at one-way doors) are the same erosion measured at two altitudes. Call any single number an estimate; measure it a few ways and it shifts a point or two. The shape does not move.</p>
+        <p>And this is the optimistic reading of the population, not the pessimistic one. I am not the worst case. I am the case who is actively paying attention, who built an instrument specifically to catch this, on his own work. If my verify rate is one in four, I would bet most people's is lower.</p>
+      </section>
+
+      <section class="doc-sec" id="indicator">
+        <span class="secnum">07</span>
+        <h2>The leading indicator</h2>
+        <p>Here is the part that is new.</p>
+        <p>Everything else in the field measures surrender <em>after</em> it shows up in the work — once output quality degrades, once a confident wrong answer ships, once the consultant underperforms. That is a lagging indicator. By the time it fires, the habit is already gone.</p>
+        <p>There is an earlier signal. Dependency erodes two things in sequence: first the capability, then the <em>wanting</em> to exercise it. Skill atrophy is the loss of the ability to check. <strong>Appetite atrophy</strong> is the loss of the desire to — and it comes first. A person who <em>can</em> still challenge the AI but no longer <em>bothers</em> is the early case, not the late one.</p>
+        <p>That is measurable. The rate at which you leave the justification blank, or type "ship it", at a one-way door — on tasks you are plainly still capable of judging — is a direct read on appetite, surfaced descriptively and tracked over time. Not "are you a compliant reviewer" but "has the wanting-to-own started to fade." Extended to the patron era, the same read becomes the <em>contest rate</em> at sign-off: when an autonomous run completes, does the human genuinely contest even one of the decisions it made on their behalf, or accept the whole thing whole?</p>
+        <p>This is the project's first leading indicator, and its sharpest contribution. It reads the fading of the instinct to own the call <em>before</em> the call goes wrong.</p>
+      </section>
+
+      <section class="doc-sec" id="not">
+        <span class="secnum">08</span>
+        <h2>What this deliberately is not</h2>
+        <p>The constraints below are not modesty. Each one is load-bearing, and removing it would break the thing.</p>
+        <ul class="doc-list">
+          <li><strong>No score.</strong> Reducing the patterns to a number re-instates the worth-by-output logic the project exists to reject, and hands the user something to game instead of something to see. The readout surfaces what you steered, checked, and let slide. Never a grade.</li>
+          <li><strong>No cross-user comparison.</strong> The unit of analysis is <em>this person, over months</em> — not a leaderboard. A ranked version would be a worse product and a worse idea.</li>
+          <li><strong>Local-first, no exfiltration.</strong> Nothing identifiable leaves the device. Privacy is not a feature here; it is the precondition for measuring honest behaviour at all. An instrument you'd perform for is an instrument that measures the performance.</li>
+          <li><strong>No cryptographic attestation — by choice.</strong> It would be natural to wrap this in tamper-evidence and sell it as an audit-grade record. I deliberately don't. Cryptography can prove a file wasn't altered; it cannot prove the words were the human's, nor that the capture was complete. A verification that can't establish what it asserts is worse than none — it manufactures false confidence. Because this instrument answers only to the person running it, it needs no proof for anyone else. The record stays a plain, append-only, local log.</li>
+          <li><strong>No real-time nagging by default.</strong> It does not interrupt during work. The one exception is reserved for the user's own highest cut-lines, opt-in, off until installed. A tool that nags is a tool people switch off on day one.</li>
+        </ul>
+      </section>
+
+      <section class="doc-sec" id="scale">
+        <span class="secnum">09</span>
+        <h2>Why a personal tool won't save the population</h2>
+        <p>I have to be honest about the ceiling, because pretending otherwise would be exactly the kind of polished overclaim this project is against.</p>
+        <p>I commissioned a synthesis of seven historical cases of automating tools and the human capacities they threatened — calculators, GPS, autopilot, ATMs, photography, spell-check, smartphones. The pattern is unambiguous:</p>
+        <ul class="doc-list">
+          <li>Capacities defended by <strong>regulated guilds with skin in the game survive.</strong> Aviation rescued hand-flying after Air France 447 with mandatory recovery training — because crashes are visible and lawyers exist.</li>
+          <li>Capacities defended by <strong>codified curriculum survive in mutated form.</strong> Mental arithmetic became estimation because a standards body wrote it into the curriculum. The meta-skill got rescued; the original didn't.</li>
+          <li>Capacities defended <strong>only by individual practice erode quietly and measurably.</strong> Spelling. Post-GPS spatial memory (Bohbot 2020). Sustained attention (average screen focus fell from 2.5 minutes in 2004 to 47 seconds in 2023). No defender, no preservation.</li>
+        </ul>
+        <p>AI is most like the undefended cases, and worse in three ways. <strong>Scope:</strong> previous tools automated narrow skills; LLMs automate the meta-skill — synthesis, judgment — that was historically the rescue route. There is no obvious "upward" from synthesis. <strong>Speed:</strong> aviation had thirty years to build its training mandate; AI capability doubles in months. <strong>Invisibility:</strong> loss of control in flight leaves craters and an NTSB report. Cognitive surrender leaves nothing — no claim, no hearing, no alarm.</p>
+        <p>The implication is hard and I will state it plainly: voluntary individual self-tracking has never preserved a capacity at population scale. The closest analogs all eroded with no defender. A practice tool genuinely helps the individual who runs it. It will not, on its own, save the population. Only three routes have ever worked — <strong>curriculum, provider infrastructure, or guild standard</strong> — each with a forcing function that is not willpower. This tool is a working demonstration of the <em>shape</em> of the missing measurement. It is not the thing that ships it at scale.</p>
+      </section>
+
+      <section class="doc-sec" id="implies">
+        <span class="secnum">10</span>
+        <h2>What this implies</h2>
+        <p>The same capture-and-synthesis substrate serves different audiences as different things — not different products, different readings of one record.</p>
+        <ul class="doc-list">
+          <li><strong>For individuals — the Mirror.</strong> Patterns over time, the surrender signatures surfaced, what got challenged versus waved through, at the one moment the loop can't watch itself: sign-off. It helps the person who runs it. Don't mistake that for solving the category.</li>
+          <li><strong>For enterprises — the Trail.</strong> The audit trail you actually need is not the AI's logs of what it did. It is the human's record of what they engaged with, challenged, and let through. AI-side-only observability is a one-sided accountability picture, and it will be a problem the first time something significant goes wrong. The requirement is that the chain of responsibility stay <em>identifiable</em> — not collapsed into "the machine."</li>
+          <li><strong>For professional bodies.</strong> The AI-collaboration audit trail will become part of professional competence within five years. The fields that codify what "competent AI use" means will define it. The fields that wait will have it defined for them.</li>
+          <li><strong>For providers.</strong> Ship the human-side counterpart to the model-side memory and observability you already build. The research agenda already names degradation of human critical thinking as a priority; the product gap is the obvious place to close it.</li>
+          <li><strong>For builders.</strong> The infrastructure is buildable today with hooks, file watchers, and scheduled exports. The hard problem is not technical. It is the design problem of surfacing the data in a way that changes behaviour without becoming insufferable. That problem is unsolved and worth working on.</li>
+        </ul>
+      </section>
+
+      <section class="doc-sec" id="questions">
+        <span class="secnum">11</span>
+        <h2>Open questions</h2>
+        <p>I do not have these answered. They are the honest edges of the work.</p>
+        <ol class="doc-oq">
+          <li><strong>What's the right unit to watch?</strong> A single turn, a whole session, the irreversible commands, or the moment you accept a long run you never watched.</li>
+          <li><strong>How much checking is silent?</strong> Reading a diff and saying nothing is real scrutiny that no transcript can see. Some of what reads as coasting may be quiet competence — and the instrument can't yet tell them apart.</li>
+          <li><strong>Does the gap compound, or self-correct?</strong> Does the drift worsen over months, or do people correct once they can see it? Answering that needs far more history than I have.</li>
+          <li><strong>Does seeing it change anything?</strong> Does showing someone their own mix change how they work, or just hand them a number to game?</li>
+          <li><strong>What's the right altitude?</strong> The individual, the team's curriculum, or the platform itself — and how do you surface it without becoming the tool people switch off on day one?</li>
+        </ol>
+      </section>
+
+      <section class="doc-sec" id="status">
+        <span class="secnum">12</span>
+        <h2>Limitations and honest status</h2>
+        <p>This is one person's data. The corpus is small (tens of classified sessions, 192 transcripts, four months, a single tool surface — maybe a fifth of even my own AI use). The headline numbers are estimates that move a point or two depending on how you slice them. Silent checking is invisible to the method and may flatter or damn me unfairly. The leading indicator in §7 has a real failure mode: if the modal answer at a one-way door is "ship it", the field is noise and the signal flatlines — in which case the artefact is theatre and the right move is to stop. I am holding that kill criterion.</p>
+        <p>What this is, then, is not a finished result. It is the form of the argument clear enough to attack and improve — with real, if undersized, data behind every claim. It is a living document; it will be revised as the corpus grows and the open questions close. The repo is public and MIT-licensed; there are no patents and there will not be, because a measurement instrument for your own judgment only works if it is inspectable.</p>
+
+        <div class="doc-foot">
+          <h3>Sources</h3>
+          <p><strong>Practitioner:</strong> Mollick, <em>Choosing to Stay Human</em> (May 2026) and <em>What it feels like to work with Mythos</em> (Jun 2026); Osmani, <em>Loop Engineering</em> (Jun 2026); Cherny (Head of Claude Code).</p>
+          <p><strong>Anthropic research:</strong> AI Fluency Index; <em>What 81,000 People Want from AI</em>; the Economic Index; Institute Research Agenda; coding-skills RCT.</p>
+          <p><strong>Academic:</strong> Dell'Acqua et al. (BCG, N=758); Lee et al., <em>Nature Scientific Reports</em> (2026, N=539); MIT Media Lab; Mark, <em>Attention Span</em> (2023); Dahmani &amp; Bohbot, <em>Scientific Reports</em> (2020); BEA, AF447 Final Report (2012); Carr, <em>The Glass Cage</em> (2014); Bessen, <em>Learning by Doing</em> (2015).</p>
+          <p class="sig">Crux · A living research document · v1 · June 2026 · No patents. Public by design.</p>
+          <a class="doc-back" href="index.html#top">← Back to the inquiry</a>
+        </div>
+      </section>
+    </article>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="foot-brand">
+        <a class="brand" href="index.html#top">cru<svg class="cx" viewBox="0 0 28 28" aria-hidden="true"><path class="x-up" d="M5 22 L23 7"/><path class="x-down" d="M5 7 L23 22"/></svg></a>
+        <p>An open inquiry into the human side of AI collaboration. Built and run in the open by Elliot Little.</p>
+      </div>
+      <div class="foot-cols">
+        <div class="foot-col">
+          <span class="foot-h mono">Project</span>
+          <a href="https://github.com/ElliotJLT/crux">GitHub</a>
+          <a href="index.html#top">The inquiry</a>
+        </div>
+        <div class="foot-col">
+          <span class="foot-h mono">Connect</span>
+          <a href="https://www.linkedin.com/in/hireelliot/">LinkedIn</a>
+          <a href="mailto:elliotjlittle@gmail.com">Email</a>
+        </div>
+      </div>
+      <div class="foot-base mono">CRUX · 2026 · MIT · A living, openly-documented inquiry</div>
+    </div>
+  </footer>
+
+  <script src="app.js"></script>
+  <script>
+    (function () {
+      var links = Array.prototype.slice.call(document.querySelectorAll('.doc-toc a'));
+      var secs = links.map(function (a) { return document.querySelector(a.getAttribute('href')); });
+      if (!('IntersectionObserver' in window)) return;
+      var spy = new IntersectionObserver(function (entries) {
+        entries.forEach(function (e) {
+          if (e.isIntersecting) {
+            var i = secs.indexOf(e.target);
+            links.forEach(function (l) { l.classList.remove('active'); });
+            if (links[i]) links[i].classList.add('active');
+          }
+        });
+      }, { rootMargin: '-15% 0px -70% 0px', threshold: 0 });
+      secs.forEach(function (s) { if (s) spy.observe(s); });
+    })();
+  </script>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -163,6 +163,56 @@ h2 { font-size: clamp(28px,4vw,46px); line-height: 1.08; letter-spacing: -0.03em
 .js .reveal.in { opacity: 1; transform: none; }
 @media (prefers-reduced-motion: reduce) { .js .reveal { opacity: 1!important; transform: none!important; } }
 
+/* RESEARCH DOCUMENT */
+.doc { max-width: 1140px; margin: 0 auto; padding: clamp(104px,14vh,148px) clamp(22px,5vw,48px) 60px; display: grid; grid-template-columns: 220px minmax(0,1fr); gap: clamp(30px,5vw,76px); align-items: start; }
+.doc-toc { position: sticky; top: 92px; display: flex; flex-direction: column; }
+.toc-h { font-family: var(--mono); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: var(--faint); margin-bottom: 14px; }
+.doc-toc a { color: var(--muted); font-size: 13px; line-height: 1.3; padding: 6px 0 6px 13px; margin-left: -1px; border-left: 2px solid var(--border); transition: color .15s, border-color .15s; }
+.doc-toc a:hover { color: var(--ink); }
+.doc-toc a.active { color: var(--ink); border-left-color: var(--orange); font-weight: 500; }
+.doc-toc a .tnum { font-family: var(--mono); font-size: 11px; color: var(--faint); margin-right: 7px; }
+.doc-toc a.active .tnum { color: var(--orange); }
+
+.doc-body { max-width: 730px; min-width: 0; }
+.doc-head { padding-bottom: 38px; margin-bottom: 46px; border-bottom: 1px solid var(--border); }
+.doc-kicker { display: inline-flex; align-items: center; gap: 9px; font-family: var(--mono); font-size: 12px; color: var(--muted); margin-bottom: 20px; }
+.doc-kicker::before { content: ""; width: 9px; height: 9px; border-radius: 2px; background: var(--orange); }
+.doc-head h1 { font-size: clamp(31px,4.4vw,50px); line-height: 1.04; letter-spacing: -0.035em; font-weight: 600; margin: 0 0 16px; }
+.doc-sub { font-size: clamp(17px,2vw,21px); color: var(--muted); font-weight: 500; letter-spacing: -0.012em; margin: 0 0 22px; }
+.doc-meta { display: flex; flex-wrap: wrap; gap: 7px 16px; font-family: var(--mono); font-size: 12px; color: var(--faint); }
+.doc-meta span { white-space: nowrap; }
+.doc-abstract { margin: 30px 0 0; padding: 22px 26px; background: var(--card); border: 1px solid var(--border); border-left: 3px solid var(--orange); border-radius: 0 14px 14px 0; }
+.doc-abstract p { margin: 0; color: var(--ink); font-size: 15.5px; line-height: 1.62; }
+.doc-abstract strong { font-weight: 600; }
+
+.doc-sec { margin: 0 0 50px; scroll-margin-top: 88px; }
+.doc-sec .secnum { font-family: var(--mono); font-size: 13px; font-weight: 600; color: var(--orange); }
+.doc-sec h2 { font-size: clamp(22px,2.7vw,31px); line-height: 1.14; letter-spacing: -0.022em; font-weight: 600; margin: 7px 0 18px; max-width: none; }
+.doc-body p { color: #2c2e33; font-size: 16.5px; line-height: 1.68; margin: 0 0 18px; }
+.doc-body p em { font-style: italic; }
+.doc-body p strong, .doc-body li strong { font-weight: 600; color: var(--ink); }
+
+.doc-list { list-style: none; padding: 0; margin: 0 0 18px; }
+.doc-list li { position: relative; padding-left: 22px; margin-bottom: 13px; color: #2c2e33; font-size: 16px; line-height: 1.62; }
+.doc-list li::before { content: ""; position: absolute; left: 3px; top: 10px; width: 6px; height: 6px; border-radius: 2px; background: var(--orange); }
+
+.doc-oq { list-style: none; counter-reset: oq; padding: 0; margin: 6px 0 18px; }
+.doc-oq li { counter-increment: oq; position: relative; padding: 16px 0 16px 44px; border-top: 1px solid var(--border); color: #2c2e33; font-size: 16px; line-height: 1.6; }
+.doc-oq li:first-child { border-top: none; }
+.doc-oq li::before { content: counter(oq); position: absolute; left: 0; top: 16px; font-family: var(--mono); font-size: 13px; font-weight: 600; color: var(--orange); }
+
+.doc-quotes { margin: 22px 0; display: flex; flex-direction: column; gap: 2px; }
+.doc-quote { margin: 0; padding: 14px 0 14px 20px; border-left: 2px solid var(--blue-deep); }
+.doc-quote p { margin: 0 0 5px; font-size: 18px; line-height: 1.4; letter-spacing: -0.015em; color: var(--ink); font-weight: 500; }
+.doc-quote cite { font-style: normal; font-size: 13px; color: var(--faint); font-family: var(--mono); }
+
+.doc-foot { margin-top: 18px; padding-top: 32px; border-top: 1px solid var(--border); }
+.doc-foot h3 { font-size: 16px; font-weight: 600; margin: 0 0 14px; }
+.doc-foot p { color: var(--muted); font-size: 13.5px; line-height: 1.65; margin: 0 0 12px; }
+.doc-foot .sig { font-family: var(--mono); font-size: 12px; color: var(--faint); margin-top: 22px; }
+.doc-back { display: inline-flex; align-items: center; gap: 7px; margin-top: 30px; font-size: 14px; color: var(--muted); font-weight: 500; }
+.doc-back:hover { color: var(--ink); }
+
 /* RESPONSIVE */
 @media (max-width: 880px) {
   .nav-links { display: none; }
@@ -170,5 +220,7 @@ h2 { font-size: clamp(28px,4vw,46px); line-height: 1.08; letter-spacing: -0.03em
   .ev-grid, .quote-grid, .steps { grid-template-columns: 1fr; }
   .footer-inner { grid-template-columns: 1fr; gap: 32px; }
   .foot-cols { justify-content: flex-start; gap: 48px; }
+  .doc { grid-template-columns: 1fr; gap: 0; }
+  .doc-toc { display: none; }
 }
 @media (max-width: 520px) { .gap-figure { flex-direction: column; } .gf-div { width: auto; height: 1px; } }


### PR DESCRIPTION
Adds the full field-study writeup as a **living research document** (not a whitepaper):

- `RESEARCH.md` — canonical, MIT, 12 sections, sources
- `docs/research.html` — styled page with sticky table-of-contents + scroll-spy, matching the site palette
- Landing page now leads with the document (hero CTA + nav link)

Goes live at https://elliotjlt.github.io/crux/research.html on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)