### PR TITLE
Fix doc nav + tone

### DIFF
--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -4,7 +4,7 @@
 
 **Elliot Little · A living research document · last updated June 2026 · v1**
 
-> This is a living research document — a field report, not a product pitch, revised as the data grows. It describes what happened when I built an instrument to measure my own judgment under AI and pointed it at four months of my own work. The headline finding is uncomfortable and specific: across more than two hundred real coding sessions, I checked whether the AI was actually right about **one time in four**. I am the person paying attention. I suspect most people's number is lower.
+> A living research document, revised as the data grows. What happened when I built an instrument to measure my own judgment under AI and pointed it at four months of my own work. The headline is uncomfortable and specific: across more than two hundred real coding sessions, I checked whether the AI was actually right about **one time in four**. I'm the person paying attention. I suspect most people's number is lower.
 
 ---
 
@@ -138,7 +138,7 @@ The constraints below are not modesty. Each one is load-bearing, and removing it
 
 ## 9. Why a personal tool won't save the population
 
-I have to be honest about the ceiling, because pretending otherwise would be exactly the kind of polished overclaim this project is against.
+The ceiling is real, and worth stating plainly.
 
 I commissioned a synthesis of seven historical cases of automating tools and the human capacities they threatened — calculators, GPS, autopilot, ATMs, photography, spell-check, smartphones. The pattern is unambiguous:
 

--- a/docs/research.html
+++ b/docs/research.html
@@ -25,9 +25,11 @@
   <header class="nav" id="nav">
     <a class="brand" href="index.html#top">cru<svg class="cx" viewBox="0 0 28 28" aria-hidden="true"><path class="x-up" d="M5 22 L23 7"/><path class="x-down" d="M5 7 L23 22"/></svg></a>
     <nav class="nav-links">
-      <a href="index.html#problem">The inquiry</a>
+      <a href="index.html#problem">Problem</a>
       <a href="index.html#evidence">Evidence</a>
-      <a href="index.html#contact">Swap notes</a>
+      <a href="index.html#finding">The finding</a>
+      <a href="index.html#approach">Approach</a>
+      <a href="research.html">The document</a>
     </nav>
     <a class="btn btn-ghost nav-cta" href="https://github.com/ElliotJLT/crux">GitHub</a>
   </header>
@@ -60,7 +62,7 @@
           <span>Elliot Little</span><span>·</span><span>Last updated June 2026</span><span>·</span><span>v1</span><span>·</span><span>No patents · public by design</span>
         </div>
         <div class="doc-abstract">
-          <p>This is a field report, not a product pitch — revised as the corpus grows. It describes what happened when I built an instrument to measure my own judgment under AI and pointed it at four months of my own work. The headline finding is uncomfortable and specific: across more than two hundred real coding sessions, I checked whether the AI was actually right about <strong>one time in four</strong>. I am the person paying attention. I suspect most people's number is lower.</p>
+          <p>What happened when I built an instrument to measure my own judgment under AI and pointed it at four months of my own work. The headline is uncomfortable and specific: across more than two hundred real coding sessions, I checked whether the AI was actually right about <strong>one time in four</strong>. I'm the person paying attention. I suspect most people's number is lower.</p>
         </div>
       </header>
 
@@ -170,7 +172,7 @@
       <section class="doc-sec" id="scale">
         <span class="secnum">09</span>
         <h2>Why a personal tool won't save the population</h2>
-        <p>I have to be honest about the ceiling, because pretending otherwise would be exactly the kind of polished overclaim this project is against.</p>
+        <p>The ceiling is real, and worth stating plainly.</p>
         <p>I commissioned a synthesis of seven historical cases of automating tools and the human capacities they threatened — calculators, GPS, autopilot, ATMs, photography, spell-check, smartphones. The pattern is unambiguous:</p>
         <ul class="doc-list">
           <li>Capacities defended by <strong>regulated guilds with skin in the game survive.</strong> Aviation rescued hand-flying after Air France 447 with mandatory recovery training — because crashes are visible and lawyers exist.</li>


### PR DESCRIPTION
Doc nav now matches landing; removed on-the-nose 'not a product pitch' framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)