### PR TITLE
Reframe the finding; cut smug line

### DIFF
--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -4,7 +4,7 @@
 
 **Elliot Little · A living research document · last updated June 2026 · v1**
 
-> A living research document, revised as the data grows. What happened when I built an instrument to measure my own judgment under AI and pointed it at four months of my own work. The headline is uncomfortable and specific: across more than two hundred real coding sessions, I checked whether the AI was actually right about **one time in four**. I'm the person paying attention. I suspect most people's number is lower.
+> A living research document, revised as the data grows. What happened when I built an instrument to measure my own judgment under AI and ran it across four months of my own work. The number that started it: across two hundred-plus sessions, I verified the AI was actually right about **one time in four**. But the number isn't the interesting part. I check the AI's *voice* far more than its *facts* — I'll fix a clumsy sentence and wave through a claim I never checked. The riskier the action, the *less* I scrutinised it, because I'd quietly switched the guardrails off. And the one habit I set out to fix came back a month later: awareness, on its own, changed nothing.
 
 ---
 
@@ -112,7 +112,7 @@ So the highest-stakes actions ran with *less* scrutiny than trivial ones, becaus
 
 The session-level finding (verifies voice, not substance) and the command-level finding (rubber stamps at one-way doors) are the same erosion measured at two altitudes. Call any single number an estimate; measure it a few ways and it shifts a point or two. The shape does not move.
 
-And this is the optimistic reading of the population, not the pessimistic one. I am not the worst case. I am the case who is actively paying attention, who built an instrument specifically to catch this, on his own work. If my verify rate is one in four, I would bet most people's is lower.
+I built this instrument specifically to catch this kind of thing, ran it on my own work half-expecting to come out fine, and it caught me anyway. That's the part I keep returning to: the awareness was already there. It wasn't enough.
 
 ## 7. The leading indicator
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -146,8 +146,8 @@
         the AI writes. I coast on whether what it says is <em>true</em>.
       </p>
       <p class="lead reveal">
-        And I'm the one paying attention. I built the tool to find this, on my own work, half-expecting to
-        come out looking fine. If my verify rate is one in four, I'd bet most people's is lower.
+        I built the tool to find this, on my own work, half-expecting to come out looking fine. It caught me
+        anyway, and that's the uncomfortable part: the awareness was already there. It wasn't enough.
       </p>
       <p class="lead dim reveal">Call it an estimate; measure it a few ways and it shifts a point or two. The shape doesn't move.</p>
     </section>

--- a/docs/research.html
+++ b/docs/research.html
@@ -62,7 +62,7 @@
           <span>Elliot Little</span><span>·</span><span>Last updated June 2026</span><span>·</span><span>v1</span><span>·</span><span>No patents · public by design</span>
         </div>
         <div class="doc-abstract">
-          <p>What happened when I built an instrument to measure my own judgment under AI and pointed it at four months of my own work. The headline is uncomfortable and specific: across more than two hundred real coding sessions, I checked whether the AI was actually right about <strong>one time in four</strong>. I'm the person paying attention. I suspect most people's number is lower.</p>
+          <p>What happened when I built an instrument to measure my own judgment under AI and ran it across four months of my own work. The number that started it: across two hundred-plus sessions, I verified the AI was actually right about <strong>one time in four</strong>. But the number isn't the interesting part. I check the AI's <em>voice</em> far more than its <em>facts</em> — I'll fix a clumsy sentence and wave through a claim I never checked. The riskier the action, the <em>less</em> I scrutinised it, because I'd quietly switched the guardrails off. And the one habit I set out to fix came back a month later: awareness, on its own, changed nothing.</p>
         </div>
       </header>
 
@@ -143,7 +143,7 @@
         <p><strong>Command level is worse, where it matters most.</strong> At the irreversible moments — the 0.45% of commands where a half-second of deliberation is obviously warranted — the dry run found 9 genuine decision events in 22 days (0.41 per day; sparse enough that capturing them would not be insufferable). Of the 8 events that had a preceding human message, <strong>roughly six were rubber stamps or blanket delegations</strong> — "go for it", "you do it all", "solve it for me". One had no human utterance at all. Contemporaneous justification at one-way doors essentially did not exist — in the person who <em>built the measurement tool</em>.</p>
         <p>So the highest-stakes actions ran with <em>less</em> scrutiny than trivial ones, because — like most solo builders — I had turned off permission prompts, dropping force-pushes and destructive migrations into the same auto-approved bucket as everything else.</p>
         <p>The session-level finding (verifies voice, not substance) and the command-level finding (rubber stamps at one-way doors) are the same erosion measured at two altitudes. Call any single number an estimate; measure it a few ways and it shifts a point or two. The shape does not move.</p>
-        <p>And this is the optimistic reading of the population, not the pessimistic one. I am not the worst case. I am the case who is actively paying attention, who built an instrument specifically to catch this, on his own work. If my verify rate is one in four, I would bet most people's is lower.</p>
+        <p>I built this instrument specifically to catch this kind of thing, ran it on my own work half-expecting to come out fine, and it caught me anyway. That's the part I keep returning to: the awareness was already there. It wasn't enough.</p>
       </section>
 
       <section class="doc-sec" id="indicator">


### PR DESCRIPTION
Lead with the substantive findings, demote the 1-in-4, remove the 'most people are worse' line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)