### PR TITLE
Research: the ownership account + the team layer (the Retro)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The synthesis surfaces whether your collaboration instincts are sharpening, plat
 
 - **Engineers** already building with AI who want a feedback loop for judgment, not just code.
 - **Tech leads** who need to develop their team's AI collaboration instincts, not just their prompt skills.
-- **Teams** where [tacit knowledge is disappearing](https://aijourn.com/are-we-automating-professional-services-into-a-knowledge-crisis/) — digests are a knowledge-transfer mechanism: juniors can see how seniors work through a problem.
+- **Teams** where [tacit knowledge is disappearing](https://aijourn.com/are-we-automating-professional-services-into-a-knowledge-crisis/) — digests are a knowledge-transfer mechanism (juniors can see how seniors work through a problem) and a retro substrate: a way to retro the collaboration, not just the product.
 
 The primary reader is always the person who runs it. It's a practice log, not a scoreboard and not a hiring signal — there are no scores and no cross-user comparison by design.
 
@@ -235,6 +235,7 @@ crux captures that layer automatically — by making it visible to the person wh
 - [Hiring Is Shifting From Syntax to Judgment](https://gritdaily.com/software-dev-hiring-shifting-from-syntax-to-judgment/) — 54x increase in aptitude assessments
 - [Are We Automating Into a Knowledge Crisis?](https://aijourn.com/are-we-automating-professional-services-into-a-knowledge-crisis/) — The tacit knowledge gap
 - [Boris Cherny: What Happens After Coding Is Solved](https://www.lennysnewsletter.com/p/head-of-claude-code-what-happens) — Head of Claude Code on the builder role
+- [Software Engineers Face an Identity Crisis (Business Insider, via Deedy Das)](https://www.businessinsider.com/software-engineers-identity-crisis-depression-ai-coding-menlo-ventures-2026) — The craftsman tax: review burden lands on the most expert; the ownership account in the wild
 - [AI vs Gen Z: The Junior Developer Crisis](https://stackoverflow.blog/2025/12/26/ai-vs-gen-z/) — How stepping-stone tasks are disappearing
 
 ## License

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -2,7 +2,7 @@
 
 ### A field study of cognitive surrender, run on my own work
 
-**Elliot Little · A living research document · last updated June 2026 · v1 · No patents, public by design**
+**Elliot Little · A living research document · last updated July 2026 · v1.1 · No patents, public by design**
 
 > *What happens to a person's judgment while the AI does the work, and can you even see it changing? This is a field report, revised as the data grows. I built an instrument to measure my own AI collaboration and ran it across four months of my own work; on the record, I visibly push back about one time in four. The number is the hook, not the point. The point is that this is not a new phenomenon — it is a forty-year-old, repeatedly replicated finding from automation research, now arriving in software — and that the person inside it is the last to be able to see it.*
 
@@ -68,6 +68,26 @@ Together they shrink the human's contact with the work to a handful of seams. In
 > "The loop doesn't know if you understand the work or are avoiding it. You do." — Addy Osmani
 
 The work has moved from process to outcome. What's left of the human's contact is three moments: **the brief**, **the mid-flight redirect**, and **the sign-off**. And the loop-engineering stack instruments every part of itself (maker/checker splits, verifier models, adversarial review), *except the human who designs it and signs off*. Osmani's line assumes the human knows the difference between using the loop to go faster and using it to avoid understanding. The evidence below says the human is the last to know.
+
+## The ownership account
+
+The studies above measure capability: comprehension scores, error rates, neural connectivity. Through mid-2026 a second account has been accumulating in practitioner writing — essays, forum threads with thousands of working engineers in them — and it is consistent enough to treat as data. Its subject is not whether the skill is decaying but whether the work still belongs to the person who shipped it. The same account comes up in private, whenever engineers are asked how the year has actually felt.
+
+The reports share a shape, and each element has a study standing behind it:
+
+- **Decisions that don't embed.** Engineers describe finishing AI-heavy projects faster and knowing them less. A decision you make lodges; a decision made mid-flight by the loop and presented for approval afterward does not. This is Kosmyna's 83%-can't-quote finding narrated from the inside — and it is what Shen & Tamkin's debugging gap predicts it should feel like six months on, when the code needs changing and the person who shipped it reads it like a stranger.
+- **The defendability test.** The practitioner version of a comprehension quiz is social: someone asks *why was this done?* and the person who shipped it can narrate the outcome but not the decisions under it. Rozenblit & Keil showed people discover the illusion of explanatory depth only when forced to explain; an AI-heavy workflow arranges for that discovery to happen out loud, in front of whoever asked.
+- **Verification as the residual job — and as tax.** Lee et al. measured the shift from doing to verifying. The practitioner accounts supply the texture: reading confident prose for the buried wrong assumption, task-switching in the minutes while the agent runs, never quite trusting what comes back. Deedy Das (Menlo Ventures, June 2026), on the split inside teams pushed to adopt: "The craftsmen are tired. Very tired. The entire burden of review falls on the craftsman. The burden of understanding." The verification lands hardest on the most expert, because they are the ones still able to do it.
+- **The reward loop, stranded.** An engineering manager, in the 8,000-upvote thread that followed Das's remarks: normal coding cycles through problem-solving and the reward of solving; AI-assisted coding parks you in "the solution validation phase" where you "barely get any reward. It becomes very mechanical and takes away what a lot of devs love about their job." That is loss of felt reward — distinct from loss of skill, and untouched by status or pay.
+- **The inversion, lived.** From the same thread: "I am no developer anymore. I am the Product Owner with the technical skill they wish they had… plus QA engineer." Mollick's patron shift, reported in the past tense from the floor.
+
+Two features of this account matter for the instrument.
+
+**It is bimodal.** The same tool, deployed the same way, lands as liberation for the outcome-oriented and as bereavement for the craft-oriented — the threads carry both voices, and the split doesn't track seniority. Population statistics will average the phenomenon away. The unit that can register it is one person, over months, which is the unit this instrument measures.
+
+**And every report is, mechanically, a missing-record problem.** The decisions existed. They were made in flight — by the person, the model, or the two of them — and left no trace the person can retrieve at the moment of challenge. Organisations are starting to answer the identity half of this with ownership: give people a problem and an outcome, not tickets. Right instinct, and it doesn't touch this. Owning an outcome without a record of the decisions underneath it is stewardship of a black box; you can only defend what you can reconstruct, and the workflow that produced the artefact is exactly the workflow that leaves no reconstruction behind.
+
+That sharpens what the digest in this project is for. Not only a mirror for judgment drift — a **record of title**: the contemporaneous account of what you steered, checked, and let slide, written while it was warm, retrievable at the moment someone asks *why*. The literature's question is whether you're still thinking. The practitioners' question is whether the work is still yours. The same record answers both.
 
 ## Method — how I captured it
 
@@ -148,6 +168,7 @@ Each constraint is load-bearing; removing it breaks the thing.
 The same capture-and-synthesis substrate serves different readers as different things — not separate products, different readings of one record.
 
 - **For individuals — the Mirror.** Patterns over time, the surrender signatures surfaced, at the one moment the loop can't watch itself: sign-off.
+- **For teams — the Retro.** Teams rebuilt how they deliver around AI in months, and mostly never retro the collaboration itself — there is no record to retro over. Workflows live in individual dotfiles and habit; loops rot when nobody owns them; the actual ways-of-working exist nowhere except transcripts nobody reads. A period of digests, shared by choice for one conversation, is the retro pack: which workflows actually ran, what got steered, what got waved through, where ownership sits. Shared reading of self-owned records, never a dashboard of anyone else.
 - **For enterprises — the Trail.** The audit trail you actually need is not the AI's logs of what it did, but the human's record of what they engaged with, challenged, and let through. AI-side-only observability is a one-sided accountability picture.
 - **For professional bodies.** The AI-collaboration audit trail will become part of professional competence within five years. The fields that codify what "competent AI use" means will define it; the rest will have it defined for them.
 - **For providers.** Ship the human-side counterpart to the model-side memory and observability you already build.
@@ -218,6 +239,7 @@ What this is, then, is not a finished result. It is the form of the argument cle
 **Practitioner & contemporary framing**
 - Mollick, E. (2026). *What It Feels Like to Work with Mythos* and *Choosing to Stay Human* (2025). One Useful Thing.
 - Osmani, A. (2026). *Loop Engineering*. Cherny, B. (2026), Head of Claude Code.
+- Das, D. (2026). On the "craftsman tax" in AI-mandated engineering teams. Menlo Ventures commentary, via Business Insider (June 2026) and the ~8,000-upvote r/technology discussion that followed. *(Practitioner reports; selection bias toward the aggrieved, counter-voices noted in text.)*
 - Anthropic. *AI Fluency Index*; *What 81,000 People Want from AI*; *The Anthropic Economic Index*.
 
-*Crux · A living research document · v1 · June 2026 · No patents. Public by design.*
+*Crux · A living research document · v1.1 · July 2026 · No patents. Public by design.*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,6 +48,18 @@ The same capture + taxonomy stack serves different audiences differently. Named 
 | Junior dev whose human-administrative bits got eaten | Repositioning | **Contribution attribution** — where your shaping actually changed the output |
 | Junior dev whose learning is threatened | Friction at the right moment | **Tutor mode** — graduated, opt-in, scoped to learning contexts |
 
+## The team layer — named, not sequenced
+
+The practitioner accounts that surfaced through mid-2026 (Das's craftsman tax and the threads that followed; the ownership account in [`RESEARCH.md`](./RESEARCH.md)) point at two pains the individual instrument doesn't reach. Both are reads of data crux already captures, not new capture surfaces.
+
+**Workflows have no home.** Skills, loops, and prompts accumulate per person — unversioned, unevaluated, unshared. Osmani's loop stack verifies every component of the loop, and nobody versions or owns the loop itself; when a loop rots, it rots silently until it's generating noise. The digest corpus already knows which workflows a person actually runs and how they change. A team-visible catalogue — which loops exist, who owns each, when it last changed, what its sessions look like — is a render mode over existing data. Ownership of a loop is also the honest answer to "what do I own now?" in a team where the AI executes: you own the system that does the work, versioned, evaluated, defensible.
+
+**The retro gap.** Teams rebuilt their delivery process around AI in months and mostly never retro the collaboration itself, because there is no record to hold the retro over. A period of digests, shared by choice for one conversation, is the retro pack: pre-readable in ten minutes, argument-ready, grounded in what actually happened rather than what people remember feeling.
+
+Constraint check, because this brushes against a hard line below: the Retro is voluntary shared reading of self-owned records, for a conversation. Not a dashboard, not a ranking, not visible to anyone the owner didn't hand it to. If it can't be built without becoming a surveillance surface, it doesn't get built.
+
+Sequencing: behind Trail Day 2 and the disclosure hook. Named now because the render-mode table already implies the tech-lead reader, and because the team is where the ownership account says the damage is compounding.
+
 ## What's NOT on this roadmap
 
 - A SaaS hosted product. Local-first, by design.

--- a/docs/research.html
+++ b/docs/research.html
@@ -40,6 +40,7 @@
       <a href="#not-new">Forty years of automation research</a>
       <a href="#software">The same pattern, in software</a>
       <a href="#why-now">Why now</a>
+      <a href="#ownership">The ownership account</a>
       <a href="#method">Method</a>
       <a href="#results">Results, run on myself</a>
       <a href="#blind">You can't see it from the inside</a>
@@ -60,7 +61,7 @@
         <h1>Measuring the human, not just the model.</h1>
         <p class="doc-sub">A field study of cognitive surrender, run on my own work.</p>
         <div class="doc-meta">
-          <span>Elliot Little</span><span>&middot;</span><span>Last updated June 2026</span><span>&middot;</span><span>v1</span><span>&middot;</span><span>No patents, public by design</span>
+          <span>Elliot Little</span><span>&middot;</span><span>Last updated July 2026</span><span>&middot;</span><span>v1.1</span><span>&middot;</span><span>No patents, public by design</span>
         </div>
         <div class="doc-abstract">
           <p>What happens to a person's judgment while the AI does the work, and can you even see it changing? This is a field report, revised as the data grows. I built an instrument to measure my own AI collaboration and ran it across four months of my own work; on the record, I visibly push back about <strong>one time in four</strong>. The number is the hook, not the point. The point is that this is not a new phenomenon, but a forty-year-old, repeatedly replicated finding from automation research now arriving in software, and that the person inside it is the last to be able to see it.</p>
@@ -123,6 +124,23 @@
           <figure class="doc-quote"><p>"The loop doesn't know if you understand the work or are avoiding it. You do."</p><cite>Addy Osmani</cite></figure>
         </div>
         <p>The work has moved from process to outcome. What's left of the human's contact is three moments: <strong>the brief</strong>, <strong>the mid-flight redirect</strong>, and <strong>the sign-off</strong>. And the loop-engineering stack instruments every part of itself (maker/checker splits, verifier models, adversarial review) except the human who designs it and signs off. Osmani's line assumes the human knows the difference between using the loop to go faster and using it to avoid understanding. The evidence below says the human is the last to know.</p>
+      </section>
+
+      <section class="doc-sec" id="ownership">
+        <h2>The ownership account</h2>
+        <p>The studies above measure capability: comprehension scores, error rates, neural connectivity. Through mid-2026 a second account has been accumulating in practitioner writing — essays, forum threads with thousands of working engineers in them — and it is consistent enough to treat as data. Its subject is not whether the skill is decaying but whether the work still belongs to the person who shipped it. The same account comes up in private, whenever engineers are asked how the year has actually felt.</p>
+        <p>The reports share a shape, and each element has a study standing behind it:</p>
+        <ul class="doc-list">
+          <li><strong>Decisions that don't embed.</strong> Engineers describe finishing AI-heavy projects faster and knowing them less. A decision you make lodges; a decision made mid-flight by the loop and presented for approval afterward does not. This is Kosmyna's 83%-can't-quote finding narrated from the inside — and it is what Shen &amp; Tamkin's debugging gap predicts it should feel like six months on, when the code needs changing and the person who shipped it reads it like a stranger.</li>
+          <li><strong>The defendability test.</strong> The practitioner version of a comprehension quiz is social: someone asks <em>why was this done?</em> and the person who shipped it can narrate the outcome but not the decisions under it. Rozenblit &amp; Keil showed people discover the illusion of explanatory depth only when forced to explain; an AI-heavy workflow arranges for that discovery to happen out loud, in front of whoever asked.</li>
+          <li><strong>Verification as the residual job — and as tax.</strong> Lee et al. measured the shift from doing to verifying. The practitioner accounts supply the texture: reading confident prose for the buried wrong assumption, task-switching in the minutes while the agent runs, never quite trusting what comes back. Deedy Das (Menlo Ventures, June 2026), on the split inside teams pushed to adopt: "The craftsmen are tired. Very tired. The entire burden of review falls on the craftsman. The burden of understanding." The verification lands hardest on the most expert, because they are the ones still able to do it.</li>
+          <li><strong>The reward loop, stranded.</strong> An engineering manager, in the 8,000-upvote thread that followed Das's remarks: normal coding cycles through problem-solving and the reward of solving; AI-assisted coding parks you in "the solution validation phase" where you "barely get any reward. It becomes very mechanical and takes away what a lot of devs love about their job." That is loss of felt reward — distinct from loss of skill, and untouched by status or pay.</li>
+          <li><strong>The inversion, lived.</strong> From the same thread: "I am no developer anymore. I am the Product Owner with the technical skill they wish they had… plus QA engineer." Mollick's patron shift, reported in the past tense from the floor.</li>
+        </ul>
+        <p>Two features of this account matter for the instrument.</p>
+        <p><strong>It is bimodal.</strong> The same tool, deployed the same way, lands as liberation for the outcome-oriented and as bereavement for the craft-oriented — the threads carry both voices, and the split doesn't track seniority. Population statistics will average the phenomenon away. The unit that can register it is one person, over months, which is the unit this instrument measures.</p>
+        <p><strong>And every report is, mechanically, a missing-record problem.</strong> The decisions existed. They were made in flight — by the person, the model, or the two of them — and left no trace the person can retrieve at the moment of challenge. Organisations are starting to answer the identity half of this with ownership: give people a problem and an outcome, not tickets. Right instinct, and it doesn't touch this. Owning an outcome without a record of the decisions underneath it is stewardship of a black box; you can only defend what you can reconstruct, and the workflow that produced the artefact is exactly the workflow that leaves no reconstruction behind.</p>
+        <p>That sharpens what the digest in this project is for. Not only a mirror for judgment drift — a <strong>record of title</strong>: the contemporaneous account of what you steered, checked, and let slide, written while it was warm, retrievable at the moment someone asks <em>why</em>. The literature's question is whether you're still thinking. The practitioners' question is whether the work is still yours. The same record answers both.</p>
       </section>
 
       <section class="doc-sec" id="method">
@@ -215,6 +233,7 @@
         <p>The same capture-and-synthesis substrate serves different readers as different things, not separate products, different readings of one record.</p>
         <ul class="doc-list">
           <li><strong>For individuals — the Mirror.</strong> Patterns over time, the surrender signatures surfaced, at the one moment the loop can't watch itself: sign-off.</li>
+          <li><strong>For teams — the Retro.</strong> Teams rebuilt how they deliver around AI in months, and mostly never retro the collaboration itself — there is no record to retro over. Workflows live in individual dotfiles and habit; loops rot when nobody owns them; the actual ways-of-working exist nowhere except transcripts nobody reads. A period of digests, shared by choice for one conversation, is the retro pack: which workflows actually ran, what got steered, what got waved through, where ownership sits. Shared reading of self-owned records, never a dashboard of anyone else.</li>
           <li><strong>For enterprises — the Trail.</strong> The audit trail you actually need is not the AI's logs of what it did, but the human's record of what they engaged with, challenged, and let through. AI-side-only observability is a one-sided accountability picture.</li>
           <li><strong>For professional bodies.</strong> The AI-collaboration audit trail will become part of professional competence within five years. The fields that codify what "competent AI use" means will define it; the rest will have it defined for them.</li>
           <li><strong>For providers.</strong> Ship the human-side counterpart to the model-side memory and observability you already build.</li>
@@ -298,6 +317,7 @@
         <ul>
           <li>Mollick, E. (2025–2026). <em>Choosing to Stay Human</em>; <em>What It Feels Like to Work with Mythos</em>. One Useful Thing.</li>
           <li>Osmani, A. (2026). <em>Loop Engineering</em>. Cherny, B. (2026), Head of Claude Code.</li>
+          <li>Das, D. (2026). On the "craftsman tax" in AI-mandated engineering teams. Menlo Ventures commentary, via Business Insider (June 2026) and the ~8,000-upvote r/technology discussion that followed. <span class="flag">(Practitioner reports; selection bias toward the aggrieved.)</span></li>
           <li>Anthropic. <em>AI Fluency Index</em>; <em>What 81,000 People Want from AI</em>; <em>The Anthropic Economic Index</em>.</li>
         </ul>
 


### PR DESCRIPTION
## What

- **RESEARCH.md + site — new section "The ownership account"** between the June-2026 discourse and Method. The practitioner counterpart to the capability studies: decisions that don't embed, the defendability test, verification as tax, the stranded reward loop, the lived director-to-reviewer inversion. Each element grounded in an already-cited study or the Das/Menlo material (Business Insider + the r/technology thread, flagged for selection bias). Ends by reframing the digest as a **record of title** — the literature asks whether you're still thinking; practitioners ask whether the work is still yours; same record answers both.
- **What this implies** — adds the team reading (**the Retro**) between Mirror and Trail: digests as the substrate for retroing the collaboration, not just the product.
- **ROADMAP — the team layer, named but not sequenced**: versioned workflow catalogue with owners, retro packs, and an explicit kill criterion if it can't be built without becoming a surveillance surface.
- **README** — retro substrate line, Das reading link. Doc stamped v1.1, July 2026.

## Why

The mid-2026 practitioner accounts (Das's craftsman tax and the threads around it) describe an ownership loss the research doc's capability framing didn't yet carry, and they point the roadmap at the team altitude the render-mode table already implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)